### PR TITLE
attempt a compatibility fix with 'apt' module

### DIFF
--- a/puppet/pivotal-pivotal_repo/manifests/init.pp
+++ b/puppet/pivotal-pivotal_repo/manifests/init.pp
@@ -71,7 +71,9 @@ class pivotal_repo (
           /^12.04/ => 'pivotal-app-suite-repo-precise'
         }
         class { 'apt':
-          always_apt_update    => true,
+          update    => {
+            frequency => 'always',
+          },
         } ->
         apt::key {'pivotal-app-suite':
           key        => '7C4B3B36',


### PR DESCRIPTION
Class parameter 'always_apt_update' is no longer supported. Replacing with update=>frequency=>always.

This simply fixes a breaking change with dependencies that require puppet 3.x+. There are many other warnings of things like future deprecated API use.
